### PR TITLE
Mejoras en subida de comida y aclaraciones

### DIFF
--- a/pages/datos_iniciales.py
+++ b/pages/datos_iniciales.py
@@ -247,7 +247,7 @@ nivel_actividad = st.selectbox("Selecciona tu nivel de actividad física:", [
 ])
 
 objetivo = st.selectbox("Selecciona tu objetivo:",
-                       ["Aumentar masa muscular", "Mantenerse", "Bajar grasa"])
+                       ["Aumentar masa muscular", "Mantenerse en un peso", "Bajar de peso"])
 
 # Mostrar y calcular tiempo de sueño
 horas_sueno = calcular_horas_de_sueno(hora_sueno, hora_despertar)
@@ -259,7 +259,10 @@ st.write("### Calculadora de Calorías: ")
 # Llamar a la función con los valores adecuados
 # Crear un botón para realizar el cálculo
 boton_calcular = st.button("CALCULAR")
+
+# Verifica si el usuario presiona el boton
 if boton_calcular:
+    # Verifica si el usuario inicio sesion
     if st.session_state["authentication_status"]:
         # Verificar si el usuario ha ingresado valores válidos
         if peso > 0 and altura > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ streamlit-authenticator
 streamlit-extras
 deta
 streamlit-lottie
+datetime


### PR DESCRIPTION
al subir los datos a la base de datos sobre las calorias consumidas, en caso de hacerlo multiples veces en un mismo dia en lugar de crear una nueva entrada se actualiza la anterior, se mejoro el formato de fechas para subir los alimentos utilizando datetime. Ahora se puede seleccionar la cantidad de porciones consumidas de un mismo alimento. El registro automaticamente crea una lista de calorias vacia para usar posteriormente en la graficacion de objetivos